### PR TITLE
ComicsParser

### DIFF
--- a/scripts/comics-parser/README.md
+++ b/scripts/comics-parser/README.md
@@ -5,11 +5,11 @@ lex and parse the extraced text of dinosaur comics, outputting them in a regular
 
 Features (it will eventually have):
 
-- [ ] remove the speaker
-- [ ] preserve case
-- [ ] preserve special characters
-- [ ] special characters are treated like their own word, except apostraphes
-- [ ] words are separated by single spaces
+- [x] remove the speaker
+- [x] preserve case
+- [x] preserve special characters
+- [x] special characters are treated like their own word, except apostraphes
+- [x] words are separated by single spaces
 
 Turning this:
 

--- a/scripts/comics-parser/src/lib.rs
+++ b/scripts/comics-parser/src/lib.rs
@@ -30,6 +30,12 @@ pub fn tokenize(input: &str) -> Vec<&str> {
     input.split_whitespace().into_iter().collect()
 }
 
+pub fn parse(input: &str) -> Vec<String> {
+    let expanded_words = expand_character_words(input);
+    let output = tokenize(&expanded_words);
+    output.into_iter().map(|w| w.into() ).collect()
+}
+
 pub fn lex(input: &String) -> Result<Vec<LexItem>, String> {
     let mut result = Vec::new();
     let mut word = Vec::new();
@@ -95,8 +101,6 @@ fn test_tokenize() {
 #[test]
 fn test_expand_and_tokenize() {
     assert_eq!(
-        tokenize(
-            &expand_character_words(
-                "I  can't    be[lie]ve   it")),
+        parse("I  can't    be[lie]ve   it"),
         vec!["I", "can\'t", "be", "[", "lie", "]", "ve", "it"]);
 }

--- a/scripts/comics-parser/src/lib.rs
+++ b/scripts/comics-parser/src/lib.rs
@@ -4,8 +4,30 @@ pub enum LexItem {
     EOL
 }
 
-pub fn is_ascii_alphanumeric_or_apostraphe(c: char) -> bool {
-    c.is_ascii_alphanumeric() || c == '\''
+pub fn is_character_word(c: char) -> bool {
+    "!\"#$%&()*+,-./:;<=>?@[]^_`{|}~".contains(c)
+}
+
+pub fn expand_character_words(input: &str) -> String {
+    let mut output = Vec::<char>::new();
+
+    for c in input.chars() {
+        match c {
+            c if is_character_word(c) => {
+                output.push(' ');
+                output.push(c);
+                output.push(' ');
+            },
+            _ => {
+                output.push(c);
+            }
+        }
+    }
+    output.into_iter().collect()
+}
+
+pub fn tokenize(input: &str) -> Vec<&str> {
+    input.split_whitespace().into_iter().collect()
 }
 
 pub fn lex(input: &String) -> Result<Vec<LexItem>, String> {
@@ -38,7 +60,7 @@ pub fn lex(input: &String) -> Result<Vec<LexItem>, String> {
                 result.push(LexItem::Word(word.clone().into_iter().collect()));
                 word.clear();
             },
-            x if is_ascii_alphanumeric_or_apostraphe(x) => {
+            x if is_character_word(x) => {
                 it.next();
 
                 word.push(x);
@@ -52,21 +74,29 @@ pub fn lex(input: &String) -> Result<Vec<LexItem>, String> {
     Ok(result)
 }
 
-pub struct ComicPanel {
-    speaker: String,
-    spoken: String
+#[test]
+fn test_expand_character_words() {
+    assert_eq!(expand_character_words(""), "");
+    assert_eq!(expand_character_words("a"), "a");
+    assert_eq!(expand_character_words("abc"), "abc");
+    assert_eq!(expand_character_words("["), " [ ");
+    assert_eq!(expand_character_words("[abc]"), " [ abc ] ");
+    assert_eq!(expand_character_words("can't"), "can't");
+    assert_eq!(expand_character_words("can! you"), "can !  you");
 }
 
-pub fn parse(input: Vec<LexItem>) -> ComicPanel {
-    let mut speaker = Vec::new();
+#[test]
+fn test_tokenize() {
+    assert_eq!(tokenize("I can't believe it"), vec!["I", "can\'t", "believe", "it"]);
+    assert_eq!(tokenize("I  can't    believe   it"), vec!["I", "can\'t", "believe", "it"]);
+    assert_eq!(tokenize("I  can't    be[lie]ve   it"), vec!["I", "can\'t", "be[lie]ve", "it"]);
+}
 
-    let iterableInput = input.iter();
-
-    for word in input.iter() {
-        match word {
-
-        }
-    }
-
-    Ok()
+#[test]
+fn test_expand_and_tokenize() {
+    assert_eq!(
+        tokenize(
+            &expand_character_words(
+                "I  can't    be[lie]ve   it")),
+        vec!["I", "can\'t", "be", "[", "lie", "]", "ve", "it"]);
 }

--- a/scripts/comics-parser/src/lib.rs
+++ b/scripts/comics-parser/src/lib.rs
@@ -1,9 +1,3 @@
-#[derive(Debug, Clone)]
-pub enum LexItem {
-    Word(String),
-    EOL
-}
-
 pub fn is_character_word(c: char) -> bool {
     "!\"#$%&()*+,-./:;<=>?@[]^_`{|}~".contains(c)
 }
@@ -34,50 +28,6 @@ pub fn parse(input: &str) -> Vec<String> {
     let expanded_words = expand_character_words(input);
     let output = tokenize(&expanded_words);
     output.into_iter().map(|w| w.into() ).collect()
-}
-
-pub fn lex(input: &String) -> Result<Vec<LexItem>, String> {
-    let mut result = Vec::new();
-    let mut word = Vec::new();
-
-    let mut it = input.chars().peekable();
-    while let Some(&c) = it.peek() {
-        match c {
-            '\n' => {
-                it.next();
-                result.push(LexItem::Word(word.clone().into_iter().collect()));
-                word.clear();
-                result.push(LexItem::EOL);
-            },
-            x if x.is_whitespace() => {
-                it.next();
-
-                if !word.is_empty() {
-                    result.push(LexItem::Word(word.clone().into_iter().collect()));
-                    word.clear();
-                }
-            },
-            x if "!\"#$%&()*+,-./:;<=>?@[]^_`{|}~".contains(x) => {
-                it.next();
-                result.push(LexItem::Word(word.clone().into_iter().collect()));
-                word.clear();
-
-                word.push(x);
-                result.push(LexItem::Word(word.clone().into_iter().collect()));
-                word.clear();
-            },
-            x if is_character_word(x) => {
-                it.next();
-
-                word.push(x);
-            },
-            _ => {
-                return Err(format!("unexpected character {}", c));
-            }
-        }
-    }
-
-    Ok(result)
 }
 
 #[test]

--- a/scripts/comics-parser/src/lib.rs
+++ b/scripts/comics-parser/src/lib.rs
@@ -1,17 +1,11 @@
 #[derive(Debug, Clone)]
-pub enum GrammarItem {
-    Speaker,
-    Sep,
-    Word,
+pub enum LexItem {
+    Word(String),
     EOL
 }
 
-#[derive(Debug, Clone)]
-pub enum LexItem {
-    Speaker(String),
-    Sep(char),
-    Word(String),
-    EOL
+pub fn is_ascii_alphanumeric_or_apostraphe(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '\''
 }
 
 pub fn lex(input: &String) -> Result<Vec<LexItem>, String> {
@@ -44,7 +38,7 @@ pub fn lex(input: &String) -> Result<Vec<LexItem>, String> {
                 result.push(LexItem::Word(word.clone().into_iter().collect()));
                 word.clear();
             },
-            x if x.is_ascii_alphanumeric() | '\'' => {
+            x if is_ascii_alphanumeric_or_apostraphe(x) => {
                 it.next();
 
                 word.push(x);
@@ -56,4 +50,23 @@ pub fn lex(input: &String) -> Result<Vec<LexItem>, String> {
     }
 
     Ok(result)
+}
+
+pub struct ComicPanel {
+    speaker: String,
+    spoken: String
+}
+
+pub fn parse(input: Vec<LexItem>) -> ComicPanel {
+    let mut speaker = Vec::new();
+
+    let iterableInput = input.iter();
+
+    for word in input.iter() {
+        match word {
+
+        }
+    }
+
+    Ok()
 }

--- a/scripts/comics-parser/src/main.rs
+++ b/scripts/comics-parser/src/main.rs
@@ -18,7 +18,7 @@ fn main() -> io::Result<()> {
     let reader = BufReader::new(file);
 
     for line in reader.lines().map(|l| l.unwrap()) {
-        comics_parser::lex(&line).expect("trouble")
+        comics_parser::parse(&line)
             .iter()
             .for_each(|p| println!("{:?}", p));
     }

--- a/scripts/comics-parser/src/main.rs
+++ b/scripts/comics-parser/src/main.rs
@@ -18,9 +18,7 @@ fn main() -> io::Result<()> {
     let reader = BufReader::new(file);
 
     for line in reader.lines().map(|l| l.unwrap()) {
-        comics_parser::parse(&line)
-            .iter()
-            .for_each(|p| println!("{:?}", p));
+        println!("{}", comics_parser::parse(&line).join(" ").split_once(":").unwrap().1.trim());
     }
 
     Ok(())


### PR DESCRIPTION
This adds a rust module to parse the extracted strings from dinocomics and:

- remove the speaker
- preserve case
- preserve special characters
- space special characters to be their own word, excepting apostrophes which are treated as embedded into other words
- normalize all words being separated by a space

This should make it easy to consume the processed output in most other tools you might want. It's also somehow wildly inefficient and wicked fast. If you need to change how characters are treated in the future, either add a new intermediary or edit the ComicsParser module to get out what you need. Most of the useful stuff is in `lib`